### PR TITLE
Timing signal modifications

### DIFF
--- a/src/experiments/experiment.py
+++ b/src/experiments/experiment.py
@@ -76,7 +76,8 @@ class experiment():
                         self.writeTTL = "None"
                     portInfo = configOptions['experiment']['ttlPort']
                     if self.writeTTL != "None":
-                        self.establishPort(self.ttlPort)
+                        self.establishPort(portInfo)
+                    
                     self.useFBO = configOptions['experiment']['useFBO']
                     self.warpFileName = configOptions['experiment']['warpFileName']
                     
@@ -133,8 +134,12 @@ class experiment():
             print('--> New TTL port has been opened')
         except serial.serialutil.SerialException:
             print('***IMPORTANT: It looks like the port you are trying to access is already in use. It may be open in a different program, or it may have never been closed by a previous instance of Bassoon. It is recommended that you close python and restart Bassoon to release the port')
+            self.writeTTL = 'None'
+            self.ttlPort = ''
         except:
-            print('***Could not open or set the serial port called ', portName, '. Ensure you\'ve selected the proper port and try again. (If this error persists, see the experiment.establishPort() method. You may need to change the parsing for how the port name is determined depending on your operating system.')
+            print('***Could not open or set the serial port called ', portName, '. Ensure you\'ve selected the proper port and try again. (If this error persists, see the experiment.establishPort() method. You may need to change the parsing for how the port name is determined depending on your operating system).')
+            self.writeTTL = 'None'
+            self.ttlPort = ''
         
         #The port should now stay open for as long as the experiment persists. If a new experiment is loaded in, the port should be reset and reopened. If
         return
@@ -203,10 +208,16 @@ class experiment():
 
             #set up the TTL ports based on the mode.
             if self.writeTTL == 'Pulse':
+                if not hasattr(self, 'portObj'):
+                    print('\n***NOTICE: stimulus ', i, 'was skipped because a TTL write method was selected, but no port has been connected to.')
+                    continue
                 p._portObj = self.portObj #initialize portObj for sending TTL pulses
                 p._portObj.rts = True #ensure TTL is OFF to begin
                 p.burstTTL(self.win) #execute a stereotyped burst to mark the start of the stimulus in pulse mode
             elif self.writeTTL == 'Sustained':
+                if not hasattr(self, 'portObj'):
+                    print('\n***NOTICE: stimulus ', i, 'was skipped because a TTL write method was selected, but no port has been connected to.')
+                    continue
                 p._portObj = self.portObj
                 p._portObj.rts = True #ensure TTL is OFF to begin
                 p._TTLON = False #used to track state of sustained TTL pulses                

--- a/src/main.py
+++ b/src/main.py
@@ -65,7 +65,7 @@ class Bassoon:
         self.optionsMenu = Menu(self.menubar, tearoff=0)
         self.menubar.add_command(label="Options", command=self.editExperiment)
         self.menubar.add_command(label ="Quick Actions", command=self.quickActionsWin)
-        self.menubar.add_command(label="Quit", command=self.frame.quit)
+        self.menubar.add_command(label="Quit", command=self.onClosing)
         master.config(menu=self.menubar)
 
         # Create a label that will provide the name of the database that is open
@@ -1309,10 +1309,12 @@ class Bassoon:
         '''
         #close any open com ports
         if self.experiment.ttlPortOpen:
-            self.experiment.portObj.close()
-            print('Closed the active serial port')
-        
-        print('--> Bassoon is closing. Goodbye!')
+            try:
+                self.experiment.portObj.close()
+                print('\nClosed the active serial port')
+            except:
+                print('\nAn open serial port was detected, but could not be closed. It is recommended that you close python and reopen before trying to run Bassoon again, otherwise you may encounter connection errors when attempting to use the same serial port.')
+        print('\n--> Bassoon is closing. Goodbye!')
         self.master.destroy()
 
 #########HELPERS##########

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,8 @@ Created on Fri Jul  9 17:23:23 2021
 
 Welcome to Bassoon. Run this file to open the GUI.
 
+Repository: www.github.com/Scottharris17/Bassoon
+
 You must have psychopy libraries installed to use built in stimuli and to achieve the necessary imports.
 www.psychopy.org
 
@@ -113,9 +115,6 @@ class Bassoon:
         # list of tuples. Position 1 = protocol name. Position 2 = protocol object
         self.experimentSketch = []
 
-        # save options
-        self.recompileExperiment = True  # option that is used by self.saveExperiment()
-
         # button grid at bottom
         self.buttonFrame = Frame(self.frame)
         self.editProtocolButton = Button(
@@ -135,9 +134,6 @@ class Bassoon:
          # Bind the on_closing function to the window close event
         master.protocol("WM_DELETE_WINDOW", self.onClosing)
         
-        #load rig configuration
-        #self.loadRigPreferences()
-
 
         print("\n\n\n-------------------Bassoon App-------------------")
         print("--> Initialization Complete!")
@@ -154,13 +150,15 @@ class Bassoon:
     def loadExperiment(self):
         '''
         Load an experiment that was previously built. This can either be a new experiment that has never been run, or an experiment that has been run before. In either case, a new experiment will be loaded into Bassoon. Properties of each protocol will be set according to those in the loaded experiment when possible. However, only attributes that are set before a protocol is run will be loaded. Properties that are set during the running of an experiment and private properties that start with '_' will not be updated.
+        
+        Perhaps confusingly, you are also not loading in the experiment settings from the previous experiment. These are specified in the config file and include things like screen name, number etc. Here, you are only loading in the protocols and their properties from a previous experiment (i.e., the experimentSketch)
         '''
         with tkfd.askopenfile(mode='rb', title="Select a file", filetypes=(("Experiment Files", "*.experiment"), ("python files", "*.py"), ("all files", "*.*"))) as exp:
             newExperimentTemplate = pickle.load(exp)
 
         self.experimentSketch = []  # clear experiment sketch if it was filled before this
-
-        newExperiment = experiment() #load a new experiment object to fill
+        self.experiment.loggedStimuli = [] # clear the logged stimuli
+        
         # iterate through the stored protocols and add them and their names to
         # the experiment sketch. Then, update
         for num, p in enumerate(newExperimentTemplate.protocolList):
@@ -509,7 +507,6 @@ class Bassoon:
         shuffleBtn = Button(macroEditFrame, text = 'Shuffle Protocols', command = lambda: shuffleProtocolList(self))
         shuffleBtn.pack(side=TOP)
         
-        
         clearBtn = Button(macroEditFrame, text = 'Clear All Protocols', command = lambda: clearProtocolList(self))
         clearBtn.pack(side=TOP)
         
@@ -700,7 +697,7 @@ class Bassoon:
             experimentFrame, text='Recompile Experiment When Saving', padx=10)
         recompileLabel.grid(row=4, column=0, columnspan=3)
         self.recompileSelection = IntVar(root)
-        self.recompileSelection.set(self.recompileExperiment)
+        self.recompileSelection.set(self.experiment.recompileExperiment)
         recompileChk = Checkbutton(
             experimentFrame, var=self.recompileSelection)
         recompileChk.grid(row=4, column=3)
@@ -727,6 +724,7 @@ class Bassoon:
         closeButton = Button(buttonFrame, text='Close Window',
                              command=lambda: monitorEditWindow.destroy())
         closeButton.grid(row=0, column=2)
+
 
     # Gamma calibration of monitor
     def calibrateGammaMenu(self):
@@ -925,7 +923,7 @@ class Bassoon:
                 
 
         self.experiment.useFBO = self.FBObjectSelection.get() == 1
-        self.recompileExperiment = self.recompileSelection.get() == 1
+        self.experiment.recompileExperiment = self.recompileSelection.get() == 1
         self.experiment.timingReport = self.timingReportSelection.get()==1
 
         print('\n--> New experiment settings have been applied')
@@ -957,7 +955,8 @@ class Bassoon:
                 "ttlPort": self.ttlPortSelection.get(),
                 "useFBO": self.FBObjectSelection.get() == 1,
                 "warpFileName": self.experiment.warpFileName,
-                "timingReport": self.timingReportSelection.get()==1
+                "timingReport": self.timingReportSelection.get()==1,
+                "recompileExperiment":self.recompileSelection.get()==1
             }
         }
 
@@ -1214,16 +1213,18 @@ class Bassoon:
 
         print('--> Assembling new experiment...')
         for p in self.experimentSketch:
-            protocolObject = p[1]
+            protocolObject = copy.deepcopy(p[1]) #do a deep copy to establish a new pointer, so that  you can update values during experiment run that won't carry over to the next experiment
             self.experiment.addProtocol(protocolObject)
 
 
-    def saveExperiment(self):
+    def saveExperiment(self, runJustFinished=False):
         '''
         save the experiment information
         '''
-        if self.recompileExperiment:
-            self.compileExperiment()
+        if self.experiment.recompileExperiment and not runJustFinished:
+            print('\n***NOTE!!! Recompiling experiment and clearing old logs. Data from past experiments will be lost, including experiment.loggedStimuli')
+            self.compileExperiment() #By default, experiments won't be recompiled after an experiment is just run because there is no conceivable reason to do so. In all other cases, it depends on the user's preference as determined by self.experiment.recompileExperiment
+            self.experiment.loggedStimuli = [] #remove the logged stimuli list
         else:
             print('--> Bassoon is saving the previously compiled experiment...')
 
@@ -1233,7 +1234,7 @@ class Bassoon:
                                           title="Save Experiment")
 
         if expfname == '':
-            print('--> Save was ABORTED. Try saving again from the Bassoon GUI or console. Recompile should be set to False in the options menu in order to keep current data...')
+            print('--> Save was ABORTED. Try saving again from the Bassoon GUI or console. Recompile should be set to False in the options menu in order to keep current data.')
             return
 
         # set wins to None type because they may still be running processes which will prevent pickling
@@ -1244,7 +1245,7 @@ class Bassoon:
 
         # save a json file as well that can be read in matlab
         jsonfname = expfname[0:-11] + '.json'
-        jsonDict = vars(self.experiment)
+        jsonDict = copy.deepcopy(vars(self.experiment))
         jsonDict['protocolList'] = [p[0] for p in jsonDict['protocolList']]
         for p in jsonDict['loggedStimuli']:
             p.pop('_portObj', None)
@@ -1277,12 +1278,10 @@ class Bassoon:
         # assemble the experiment
         self.compileExperiment()
 
-        self.recompileExperiment = False
-
         # add all protocol objects to the experiment
         print(' \n--> Preparing to run experiment. Bassoon will become tacet.')
 
-        root.withdraw()  # hide bassoon while the experiment is running
+        root.withdraw()  #hide bassoon while the experiment is running
         print('--> Tacet!')
         print('--> Experiment is now live! If available, use the information window for further assistance. Good luck.')
 
@@ -1293,11 +1292,11 @@ class Bassoon:
         try:
             print('\n--> The experiment has ended. Please save.')
             # pass recompile = False becasue you want to save the experiment that you just ran, not a new one
-            self.saveExperiment()
+            self.saveExperiment(runJustFinished = True) #recompileOption not passed (defaults to false, because you want to save the experiment you just ran)
 
         except:
             print('\n***NOTICE: THE PRECEEDING EXPERIMENT WAS NOT SAVED. MANUALLY SAVE BEFORE PROCEEDING OR THE EXPERIMENT WILL BE LOST.' +
-                  '\n--> Invoke app.recompileExperiment = False; app.saveExperiment() to save the experiment.' +
+                  '\n--> Invoke app.experiment.recompileExperiment = False; app.saveExperiment() to save the experiment.' +
                   '\n--> Alternatively, the experiment object is located at app.experiment. However, this object may not be immediately pickalable without invoking \'app.experiment.win = None\' and \'app.experiment.informationWin = None\'')
 
         print('\n\nBassoon is ready to play again!')
@@ -1351,13 +1350,16 @@ root = Tk()  # full function = tk.Tk()
 root.geometry('400x600')
 #root.iconbitmap(r'images\bassoonIcon.ico')
 app = Bassoon(root)
-
 root.mainloop()
-
+try:
+    root.destroy()
+except:
+    pass #normally root.destroy is not needed because it's handled in app.onClosing()
+    
 
 # Example of how to load experiments without opening the GUI:
 # e = experiment() #load an experiment object
-# b = MovingBar() #load a protocol subclass (i.e. a stimulus)
+# b = MovingBar() #load a protocol (i.e. a stimulus)
 # b.stimTime = 3 #change stimulus attributes as you see fit
 # e.addProtocol(b) #Add the modified stimulus to the experiment
 

--- a/src/protocols/protocol.py
+++ b/src/protocols/protocol.py
@@ -58,7 +58,7 @@ class protocol():
         estimateTime place holder. Should be overriden in subclass
         '''
         return 0
-    
+        
     
     def getFR(self, win):
         '''

--- a/src/protocols/protocol.py
+++ b/src/protocols/protocol.py
@@ -26,6 +26,7 @@ class protocol():
         self._numberOfEpochsStarted = 0
         self._numberOfEpochsCompleted = 0 #counts the number of epochs that have actually occured
         
+        self._portName = '' #name of the TTL port if in use. Implemented 
         self._timesTTLFlipped = 0 #counts the number of TTL flips, used for sustained mode only
         self._timesTTLFlippedBookmark = 0 #counts the number of TTL flips during bookmark (sustained mode with bookmarking only)
         
@@ -86,7 +87,6 @@ class protocol():
         '''
         determine the pixels per degree for the stimulus monitor
         '''
-
         mon = monitors.Monitor(stimMonitor.name)
         eyeDistance = mon.getDistance()
         numPixelsWide = mon.currentCalib['sizePix'][0]
@@ -140,7 +140,7 @@ class protocol():
         '''
         if self.writeTTL == 'Pulse':
                 try:
-                    self._portObj.write(0X4B) #self._portObj is initialized in the experiment.activate() method
+                    self._portObj.write(0X4B)
                 except:
                     print('***WARNING: TTL Pulse Failed***')
         
@@ -151,17 +151,17 @@ class protocol():
                 self._timesTTLFlipped += 1
                 
             if self._TTLON: #IF TTL is ON, turn it OFF
-                self._portObj.setRTS(True) #'True' turns TTL off on picolo
+                self._portObj.rts = True #'True' turns TTL off on picolo
                 self._TTLON = False
             else: # If TTL is OFF, turn it ON
-                self._portObj.setRTS(False) #'False' turns TTL ON on picolo
+                self._portObj.rts = False #'False' turns TTL ON on picolo
                 self._TTLON = True
         return
     
     
     def burstTTL(self, win):
         '''
-        sends a burst of TTL pulses at the start of a stimulus when the the TTL port is in pulse mode. As of 10/29/2023 this appears to only be implemented for checkerboard receptive field and flash grid. The stereotyped busrt is 20 TTL pulses at frame rate, wait 0.2 seconds, and 20 more TTL pulses at frame rate
+        sends a burst of TTL pulses at the start of a stimulus when the the TTL port is in pulse mode. As of 10/29/2023 this appears to only be implemented for checkerboard receptive field and flash grid. The stereotyped burst is 20 TTL pulses at frame rate, wait 0.2 seconds, and 20 more TTL pulses at frame rate
         '''
         if self.writeTTL != 'Pulse':
             return


### PR DESCRIPTION
Fixed serial port handling to keep the port open the entire time the app is open. This prevents the port from reverting to its default voltage when it is erased from memory.

Also made updates to the recompile when saving option that improves functionality and handles some small bugs that were present. Of note, now when recompile when save is on, experiment.loggedStimuli() is cleared during the save. This is not recoverable. Thus recompile is forced off when the automatic save window opens after a run.